### PR TITLE
documentation changes: use Geyser API instead of Base API

### DIFF
--- a/src/main/resources/extension.yml
+++ b/src/main/resources/extension.yml
@@ -1,6 +1,6 @@
 id: exampleid
 name: ExampleExtension
 main: org.geyser.extension.exampleid.ExampleExtension
-api: 1.0.0
+api: 2.1.1
 version: 1.0.0
 authors: [ExampleAuthor]

--- a/src/main/resources/extension.yml
+++ b/src/main/resources/extension.yml
@@ -1,6 +1,6 @@
 id: exampleid
 name: ExampleExtension
 main: org.geyser.extension.exampleid.ExampleExtension
-api: 2.1.1
+api: 2.4.1
 version: 1.0.0
 authors: [ExampleAuthor]

--- a/src/main/resources/extensionyml-README.md
+++ b/src/main/resources/extensionyml-README.md
@@ -10,7 +10,7 @@ main is the main class of your extension, that will be loaded by Geyser.
 **main: org.geyser.extension.exampleid.ExampleExtension**
 
 api is the version of the Geyser API that your extension uses.  
-**api: 2.1.1**
+**api: 2.4.1**
 
 version is the version of your extension, you can bump it to indicate an update.  
 **version: 1.0.1**

--- a/src/main/resources/extensionyml-README.md
+++ b/src/main/resources/extensionyml-README.md
@@ -9,8 +9,8 @@ name is the name of your extension. It can be anything.
 main is the main class of your extension, that will be loaded by Geyser.  
 **main: org.geyser.extension.exampleid.ExampleExtension**
 
-api is the version of the extension API that your extension uses.  
-**api: 1.0.0**
+api is the version of the Geyser API that your extension uses.  
+**api: 2.1.1**
 
 version is the version of your extension, you can bump it to indicate an update.  
 **version: 1.0.1**


### PR DESCRIPTION
Depends on https://github.com/GeyserMC/api/pull/2 and https://github.com/GeyserMC/Geyser/pull/3880.
Once those are merged, extensions should specify the Geyser API instead of the Base API version.